### PR TITLE
fix(api): update siwe domain to skillbridge.agarwalvivek.com

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -24,7 +24,7 @@ JWT_SECRET=replace-me-with-32-char-minimum-random-string
 JWT_EXPIRY_SECONDS=3600
 
 # Domain used for SIWE (EIP-4361) message verification — must match the frontend hostname
-SIWE_DOMAIN=skillbridge.xyz
+SIWE_DOMAIN=skillbridge.agarwalvivek.com
 
 # Shared API key for service-to-service (BE↔BE) communication.
 # Set the same value in all services. Generate with: openssl rand -hex 32

--- a/services/api/src/config.py
+++ b/services/api/src/config.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     jwt_secret: str
     jwt_expiry_seconds: int = 3600
     api_key: str
-    siwe_domain: str = "skillbridge.xyz"
+    siwe_domain: str = "skillbridge.agarwalvivek.com"
 
     # Blockchain
     base_rpc_url: str = "https://sepolia.base.org"

--- a/services/api/tests/e2e/test_auth.py
+++ b/services/api/tests/e2e/test_auth.py
@@ -16,7 +16,7 @@ from siwe import SiweMessage
 # Deterministic test wallet (never use with real funds)
 _PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6e538eba2ef5cf0e6e91a74b5e3e1e3a3c34"
 _WALLET = Account.from_key(_PRIVATE_KEY).address
-_DOMAIN = "skillbridge.xyz"
+_DOMAIN = "skillbridge.agarwalvivek.com"
 
 
 def _build_siwe_message(nonce: str, wallet: str = _WALLET) -> str:

--- a/services/api/tests/unit/test_siwe.py
+++ b/services/api/tests/unit/test_siwe.py
@@ -11,7 +11,7 @@ from src.domain.auth import verify_siwe_signature
 # Deterministic test key (never used with real funds)
 _PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6e538eba2ef5cf0e6e91a74b5e3e1e3a3c34"
 _WALLET = Account.from_key(_PRIVATE_KEY).address
-_DOMAIN = "skillbridge.xyz"
+_DOMAIN = "skillbridge.agarwalvivek.com"
 
 
 def _build_siwe_message(nonce: str, wallet: str = _WALLET) -> str:


### PR DESCRIPTION
## Summary

- Updates `siwe_domain` default in `Settings` from `skillbridge.xyz` → `skillbridge.agarwalvivek.com`
- Updates `SIWE_DOMAIN` placeholder in `.env.example`
- Updates `_DOMAIN` constant in unit and e2e test fixtures to match

## Files changed

- `services/api/src/config.py` — default value
- `services/api/.env.example` — placeholder
- `services/api/tests/unit/test_siwe.py` — test fixture domain
- `services/api/tests/e2e/test_auth.py` — test fixture domain