### PR TITLE
chore(git): add pre-push hook blocking direct pushes to main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,16 @@
+# pre-push hook — runs before each push
+# Blocks direct pushes to main or master
+
+BRANCH=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+REMOTE_REF=$(cat /dev/stdin | awk '{print $2}')
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ] || \
+   [ "$REMOTE_REF" = "refs/heads/main" ] || [ "$REMOTE_REF" = "refs/heads/master" ]; then
+  echo ""
+  echo "ERROR: Direct push to '$BRANCH' is not allowed."
+  echo "All changes must go through a pull request."
+  echo "  1. Create a feature branch: git checkout -b feat/your-feature"
+  echo "  2. Push the branch and open a PR"
+  echo ""
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 ## Project Context
 
 Read these before every session:
+
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — system overview, service map, data flow, tech stack, constraints
 - **[PRODUCT.md](PRODUCT.md)** — product vision, target users, core features, roadmap
 
@@ -34,15 +35,18 @@ Before starting any task, you MUST:
 ## Workflow Gates
 
 ### Gate 1: Spec Gate
+
 - **Non-trivial features require a spec.** If `docs/specs/[ISSUE-NUMBER]-*.md` does not exist, create it using `docs/specs/TEMPLATE.md` before writing any implementation code.
 - Bug fixes, dependency updates, and documentation changes are exempt.
 
 ### Gate 2: Plan Gate
+
 - **Changes touching more than 2 files or introducing new architecture require an approved plan.**
 - Use `EnterPlanMode` to explore, design, and present your plan. Do not write production code during planning.
 - Exit planning only after the plan is approved by the user.
 
 ### Gate 3: ADR Gate
+
 - **Any architectural decision requires an ADR.** See `docs/adr/README.md` for what triggers an ADR.
 - Create the ADR in `docs/adr/[NNNN]-[title].md` before implementing the decision.
 
@@ -55,6 +59,7 @@ Before starting any task, you MUST:
 - **Never skip git hooks.** Do not use `--no-verify` or `--no-gpg-sign`.
 - **Never add AI attribution.** Do not add `Co-Authored-By: Claude` or any mention of Claude, Anthropic, or AI tooling in commit messages or PR bodies.
 - **Never commit to `main` directly.** All changes go through a PR on a feature branch.
+- **Never push to `main` directly.** The `.husky/pre-push` hook enforces this — it will reject any push targeting `main` or `master`. If a push to main is needed, it must have explicit human approval first.
 - **Never hardcode secrets.** Use `.env` files (gitignored). Update `.env.example` with placeholder values.
 - **Never modify `infra/docker-compose.yml` or AWS configs without explicit human approval.**
 
@@ -82,6 +87,7 @@ Maintain `.claude/memory/` to preserve context across sessions:
 - Topic files (e.g., `auth.md`, `database.md`) — detailed notes linked from `MEMORY.md`
 
 Write to memory when you discover:
+
 - Stable architectural patterns in this repo
 - Non-obvious conventions or gotchas
 - Important file paths and entry points
@@ -159,34 +165,38 @@ Never define a `type`, `interface`, `struct`, `class`, `dataclass`, or `enum` fo
 Any time a feature is added, changed, or removed — whether from a user request, a PR review, or a design decision — you MUST execute this protocol in full before touching any service code:
 
 ### Step 1 — Update the proto schema
+
 - Identify every `.proto` file in `packages/schema/proto/` that is affected by the change (new fields, new messages, renamed fields, new enum values, etc.)
 - Apply all changes to the proto files
 - Run `cd packages/schema && ./scripts/generate.sh` to regenerate bindings
 - Commit proto + generated files before any service code is written
 
 ### Step 2 — Update open GitHub issues
+
 - Review every open issue on `agarwalvivek29/skillbridge`
 - For each issue whose **Acceptance Criteria**, **Technical Notes**, or proto references are now stale due to the feature change, edit the issue body to reflect the updated design
 - Pay special attention to: field renames, new required fields, changed status lifecycles, new notification types, and changed service dependencies
 
 ### Step 3 — Create follow-up issues for affected modules
+
 - If the feature change impacts a service or module that has no open issue tracking the required update, **create a new GitHub issue** covering that update
 - Use the same format as existing issues (Summary, Acceptance Criteria, Technical Notes, Spec)
 - Common triggers for new issues: a new entity added to `proto/` that needs a DB migration, a new event type that `notifications` must handle, a new proto field that the `web` UI must surface, a contract change that `api` must relay
 
 ### Step 4 — Update ARCHITECTURE.md
+
 - If the change affects the Core Domain Model table (new entity, renamed field, changed lifecycle), update `ARCHITECTURE.md` immediately
 - Commit the architecture update in the same commit as the proto change, or in the immediately following commit
 
 ### Summary table
 
-| What changed | Proto | Issues | New issues | ARCHITECTURE.md |
-|---|---|---|---|---|
-| New field on existing entity | Update proto | Update issues referencing that entity | If a new DB column is needed | Update domain model table |
-| New entity / message | Add proto file | Update issues that depend on it | Create issue for each service that must implement it | Add row to domain model |
-| Renamed field | Update proto | Update ALL issues using old name | — | Update if field is in the table |
-| New enum value | Update proto | Update issues for features that trigger/consume it | Create notification issue if it's a new notification type | — |
-| Removed feature | Remove/deprecate proto | Close or update affected issues | Create cleanup issues if code already merged | Remove from domain model |
+| What changed                 | Proto                  | Issues                                             | New issues                                                | ARCHITECTURE.md                 |
+| ---------------------------- | ---------------------- | -------------------------------------------------- | --------------------------------------------------------- | ------------------------------- |
+| New field on existing entity | Update proto           | Update issues referencing that entity              | If a new DB column is needed                              | Update domain model table       |
+| New entity / message         | Add proto file         | Update issues that depend on it                    | Create issue for each service that must implement it      | Add row to domain model         |
+| Renamed field                | Update proto           | Update ALL issues using old name                   | —                                                         | Update if field is in the table |
+| New enum value               | Update proto           | Update issues for features that trigger/consume it | Create notification issue if it's a new notification type | —                               |
+| Removed feature              | Remove/deprecate proto | Close or update affected issues                    | Create cleanup issues if code already merged              | Remove from domain model        |
 
 ---
 
@@ -222,13 +232,13 @@ When in doubt: stop, explain what you were about to do, and ask.
 
 ## Quick Reference
 
-| Situation | Action |
-|---|---|
-| Feature request with no spec | Create spec first, then plan |
-| Architectural decision needed | Create ADR before implementing |
-| Task touches >2 files | EnterPlanMode |
-| Unclear requirements | AskUserQuestion — never assume |
-| Potential secret in code | Flag it, do not commit |
-| CI check failing | Fix root cause, never use --no-verify |
-| New service needed | Run `scripts/new-service.sh` |
+| Situation                         | Action                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Feature request with no spec      | Create spec first, then plan                                                                           |
+| Architectural decision needed     | Create ADR before implementing                                                                         |
+| Task touches >2 files             | EnterPlanMode                                                                                          |
+| Unclear requirements              | AskUserQuestion — never assume                                                                         |
+| Potential secret in code          | Flag it, do not commit                                                                                 |
+| CI check failing                  | Fix root cause, never use --no-verify                                                                  |
+| New service needed                | Run `scripts/new-service.sh`                                                                           |
 | Feature added / changed / removed | Run Feature Change Protocol: update proto → update issues → create new issues → update ARCHITECTURE.md |


### PR DESCRIPTION
## Summary
- Adds a Husky `pre-push` hook that rejects any direct push targeting `main` or `master`
- Enforces the branch protection policy defined in `CLAUDE.md` at the git client level

## Test plan
- [ ] Verify `git push origin main` is rejected with a clear error message
- [ ] Verify pushing feature branches works normally