### PR TITLE
chore(git): auto-regenerate proto bindings in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,17 @@
 # pre-commit hook — runs before each commit
 # Enforces: lint and format checks on staged files
+# Auto-regenerates proto bindings when .proto files are staged
 
+# ── Proto regeneration ────────────────────────────────────────────────────────
+STAGED_PROTOS=$(git diff --cached --name-only | grep '\.proto$' || true)
+
+if [ -n "$STAGED_PROTOS" ]; then
+  echo "▶ Proto files staged — regenerating bindings..."
+  cd packages/schema && ./scripts/generate.sh --skip-breaking
+  cd - > /dev/null
+  git add packages/schema/generated/
+  echo "✓ Generated files auto-staged"
+fi
+
+# ── Lint / format ─────────────────────────────────────────────────────────────
 npx lint-staged


### PR DESCRIPTION
## Summary
- When `.proto` files are staged, the pre-commit hook now automatically runs `packages/schema/scripts/generate.sh` and stages the output in `packages/schema/generated/`
- Uses `--skip-breaking` flag since breaking change detection belongs in CI, not local commits
- Prevents agents and contributors from accidentally committing proto changes without regenerating bindings

## How it works
```
git add some-file.proto
git commit  # hook detects staged .proto → runs generate.sh → auto-adds generated/ → proceeds to lint-staged
```

## Test plan
- [ ] Stage a `.proto` file change and commit — verify generated files are auto-staged
- [ ] Commit without any `.proto` changes — verify hook skips regeneration and proceeds normally