### PR TITLE
chore(schema): update escrow proto for Solana (#68)

### DIFF
--- a/packages/schema/generated/go/contracts/v1/escrow.pb.go
+++ b/packages/schema/generated/go/contracts/v1/escrow.pb.go
@@ -89,22 +89,22 @@ type EscrowContract struct {
 
 	Id    string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	GigId string `protobuf:"bytes,2,opt,name=gig_id,json=gigId,proto3" json:"gig_id,omitempty"`
-	// Deployed GigEscrow contract address on Base L2
+	// Deployed escrow PDA address on Solana (base58 format)
 	ChainAddress string `protobuf:"bytes,3,opt,name=chain_address,json=chainAddress,proto3" json:"chain_address,omitempty"`
-	// "base-mainnet" or "base-sepolia"
+	// "solana-mainnet-beta", "solana-devnet", or "solana-localnet"
 	Network string `protobuf:"bytes,4,opt,name=network,proto3" json:"network,omitempty"`
-	// Total amount locked — in wei (ETH) or 6-decimal units (USDC)
+	// Total amount locked — in lamports (SOL) or 6-decimal units (USDC)
 	TotalAmount string `protobuf:"bytes,5,opt,name=total_amount,json=totalAmount,proto3" json:"total_amount,omitempty"`
 	// Amount released so far
 	ReleasedAmount string       `protobuf:"bytes,6,opt,name=released_amount,json=releasedAmount,proto3" json:"released_amount,omitempty"`
 	Status         EscrowStatus `protobuf:"varint,7,opt,name=status,proto3,enum=contracts.v1.EscrowStatus" json:"status,omitempty"`
-	// ETH: empty string (native asset). USDC: ERC-20 contract address on Base L2.
+	// SOL: empty string (native asset). USDC: SPL token mint address on Solana (base58).
 	TokenAddress string `protobuf:"bytes,8,opt,name=token_address,json=tokenAddress,proto3" json:"token_address,omitempty"`
 	// Platform fee in basis points (500 = 5%). Stored in the contract at deploy time.
 	PlatformFeeBasisPoints int32 `protobuf:"varint,9,opt,name=platform_fee_basis_points,json=platformFeeBasisPoints,proto3" json:"platform_fee_basis_points,omitempty"`
 	// Computed platform fee amount (total_amount * platform_fee_basis_points / 10000)
 	PlatformFeeAmount string `protobuf:"bytes,10,opt,name=platform_fee_amount,json=platformFeeAmount,proto3" json:"platform_fee_amount,omitempty"`
-	// Wallet that receives the platform fee on each completeMilestone call
+	// Solana wallet address (base58) that receives the platform fee on each completeMilestone call
 	PlatformFeeRecipient string `protobuf:"bytes,11,opt,name=platform_fee_recipient,json=platformFeeRecipient,proto3" json:"platform_fee_recipient,omitempty"`
 	// Transaction hash of the funding tx
 	FundingTxHash string                 `protobuf:"bytes,12,opt,name=funding_tx_hash,json=fundingTxHash,proto3" json:"funding_tx_hash,omitempty"`

--- a/packages/schema/generated/python/contracts/v1.py
+++ b/packages/schema/generated/python/contracts/v1.py
@@ -22,16 +22,17 @@ class EscrowStatus(betterproto.Enum):
 class EscrowContract(betterproto.Message):
     id: str = betterproto.string_field(1)
     gig_id: str = betterproto.string_field(2)
-    # Deployed GigEscrow contract address on Base L2
+    # Deployed escrow PDA address on Solana (base58 format)
     chain_address: str = betterproto.string_field(3)
-    # "base-mainnet" or "base-sepolia"
+    # "solana-mainnet-beta", "solana-devnet", or "solana-localnet"
     network: str = betterproto.string_field(4)
-    # Total amount locked — in wei (ETH) or 6-decimal units (USDC)
+    # Total amount locked — in lamports (SOL) or 6-decimal units (USDC)
     total_amount: str = betterproto.string_field(5)
     # Amount released so far
     released_amount: str = betterproto.string_field(6)
     status: "EscrowStatus" = betterproto.enum_field(7)
-    # ETH: empty string (native asset). USDC: ERC-20 contract address on Base L2.
+    # SOL: empty string (native asset). USDC: SPL token mint address on Solana
+    # (base58).
     token_address: str = betterproto.string_field(8)
     # Platform fee in basis points (500 = 5%). Stored in the contract at deploy
     # time.
@@ -39,7 +40,8 @@ class EscrowContract(betterproto.Message):
     # Computed platform fee amount (total_amount * platform_fee_basis_points /
     # 10000)
     platform_fee_amount: str = betterproto.string_field(10)
-    # Wallet that receives the platform fee on each completeMilestone call
+    # Solana wallet address (base58) that receives the platform fee on each
+    # completeMilestone call
     platform_fee_recipient: str = betterproto.string_field(11)
     # Transaction hash of the funding tx
     funding_tx_hash: str = betterproto.string_field(12)

--- a/packages/schema/generated/ts/contracts/v1/escrow_pb.ts
+++ b/packages/schema/generated/ts/contracts/v1/escrow_pb.ts
@@ -29,21 +29,21 @@ export type EscrowContract = Message<"contracts.v1.EscrowContract"> & {
   gigId: string;
 
   /**
-   * Deployed GigEscrow contract address on Base L2
+   * Deployed escrow PDA address on Solana (base58 format)
    *
    * @generated from field: string chain_address = 3;
    */
   chainAddress: string;
 
   /**
-   * "base-mainnet" or "base-sepolia"
+   * "solana-mainnet-beta", "solana-devnet", or "solana-localnet"
    *
    * @generated from field: string network = 4;
    */
   network: string;
 
   /**
-   * Total amount locked — in wei (ETH) or 6-decimal units (USDC)
+   * Total amount locked — in lamports (SOL) or 6-decimal units (USDC)
    *
    * @generated from field: string total_amount = 5;
    */
@@ -62,7 +62,7 @@ export type EscrowContract = Message<"contracts.v1.EscrowContract"> & {
   status: EscrowStatus;
 
   /**
-   * ETH: empty string (native asset). USDC: ERC-20 contract address on Base L2.
+   * SOL: empty string (native asset). USDC: SPL token mint address on Solana (base58).
    *
    * @generated from field: string token_address = 8;
    */
@@ -83,7 +83,7 @@ export type EscrowContract = Message<"contracts.v1.EscrowContract"> & {
   platformFeeAmount: string;
 
   /**
-   * Wallet that receives the platform fee on each completeMilestone call
+   * Solana wallet address (base58) that receives the platform fee on each completeMilestone call
    *
    * @generated from field: string platform_fee_recipient = 11;
    */

--- a/packages/schema/proto/contracts/v1/escrow.proto
+++ b/packages/schema/proto/contracts/v1/escrow.proto
@@ -23,22 +23,22 @@ enum EscrowStatus {
 message EscrowContract {
   string id = 1;
   string gig_id = 2;
-  // Deployed GigEscrow contract address on Base L2
+  // Deployed escrow PDA address on Solana (base58 format)
   string chain_address = 3;
-  // "base-mainnet" or "base-sepolia"
+  // "solana-mainnet-beta", "solana-devnet", or "solana-localnet"
   string network = 4;
-  // Total amount locked — in wei (ETH) or 6-decimal units (USDC)
+  // Total amount locked — in lamports (SOL) or 6-decimal units (USDC)
   string total_amount = 5;
   // Amount released so far
   string released_amount = 6;
   EscrowStatus status = 7;
-  // ETH: empty string (native asset). USDC: ERC-20 contract address on Base L2.
+  // SOL: empty string (native asset). USDC: SPL token mint address on Solana (base58).
   string token_address = 8;
   // Platform fee in basis points (500 = 5%). Stored in the contract at deploy time.
   int32 platform_fee_basis_points = 9;
   // Computed platform fee amount (total_amount * platform_fee_basis_points / 10000)
   string platform_fee_amount = 10;
-  // Wallet that receives the platform fee on each completeMilestone call
+  // Solana wallet address (base58) that receives the platform fee on each completeMilestone call
   string platform_fee_recipient = 11;
   // Transaction hash of the funding tx
   string funding_tx_hash = 12;


### PR DESCRIPTION
## Summary

- Updated all comments in `escrow.proto` to reflect Solana instead of Base L2:
  - `chain_address`: now references Solana PDA address in base58 format
  - `network`: now lists `solana-mainnet-beta`, `solana-devnet`, `solana-localnet`
  - `total_amount`: changed from wei (ETH) to lamports (SOL)
  - `token_address`: changed from ERC-20 on Base L2 to SPL token mint on Solana (base58)
  - `platform_fee_recipient`: now specifies Solana wallet address format (base58)
- Regenerated all bindings (Go, Python, TypeScript)

No field names, numbers, or types were changed — the wire format is completely unchanged.

## Test plan

- [x] Proto file lints cleanly via `buf lint`
- [x] Bindings regenerate successfully via `generate.sh`
- [x] Only comment text changed in generated output (verified via `git diff`)

Closes #68