### PR TITLE
fix(web): currency prop threading and type extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ agent-orchestrator.yaml
 tmp/
 temp/
 .env.postgres
+.vercel

--- a/apps/web/app/gigs/[id]/workspace/page.tsx
+++ b/apps/web/app/gigs/[id]/workspace/page.tsx
@@ -45,10 +45,12 @@ function MilestoneTimeline({
   milestones,
   submissions,
   gigId,
+  currency,
 }: {
   milestones: WorkspaceData["gig"]["milestones"];
   submissions: WorkspaceSubmission[];
   gigId: string;
+  currency: string;
 }) {
   const [expanded, setExpanded] = useState<string | null>(
     milestones.find(
@@ -113,10 +115,7 @@ function MilestoneTimeline({
                   <StatusBadge status={m.status} />
                 </div>
                 <p className="mt-0.5 text-xs text-neutral-500">
-                  {formatAmountWithCurrency(
-                    m.amount,
-                    m.currency || gig.currency,
-                  )}
+                  {formatAmountWithCurrency(m.amount, m.currency || currency)}
                 </p>
               </div>
               {isExpanded ? (
@@ -283,6 +282,7 @@ function WorkspaceContent() {
               milestones={gig.milestones}
               submissions={submissions}
               gigId={gig.id}
+              currency={gig.currency}
             />
           </Card>
         </div>

--- a/apps/web/components/ui/EmptyState.tsx
+++ b/apps/web/components/ui/EmptyState.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "./Button";
@@ -8,6 +9,7 @@ interface EmptyStateProps {
   description?: string;
   actionLabel?: string;
   onAction?: () => void;
+  actionHref?: string;
   className?: string;
 }
 
@@ -17,6 +19,7 @@ export function EmptyState({
   description,
   actionLabel,
   onAction,
+  actionHref,
   className,
 }: EmptyStateProps) {
   return (
@@ -28,7 +31,14 @@ export function EmptyState({
       {description && (
         <p className="mt-1 text-sm text-neutral-500">{description}</p>
       )}
-      {actionLabel && onAction && (
+      {actionLabel && actionHref && (
+        <Link href={actionHref}>
+          <Button variant="primary" size="md" className="mt-4">
+            {actionLabel}
+          </Button>
+        </Link>
+      )}
+      {actionLabel && onAction && !actionHref && (
         <Button variant="primary" size="md" onClick={onAction} className="mt-4">
           {actionLabel}
         </Button>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/apps/web/types/escrow.ts
+++ b/apps/web/types/escrow.ts
@@ -7,6 +7,12 @@
 export interface EscrowTx {
   /** Base64-encoded serialized Solana transaction */
   serialized_tx: string;
+  /** Solana program ID for the escrow contract */
+  program_id: string;
+  /** PDA derivation seeds */
+  escrow_seeds: string[];
+  /** Amount in lamports */
+  amount: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix currency prop threading in MilestoneTimeline — pass `currency` explicitly instead of referencing undefined `gig` variable
- Add `actionHref` prop to EmptyState component for link-based actions
- Extend EscrowTx type with `program_id`, `escrow_seeds`, and `amount` fields
- Set tsconfig target to `es2017`
- Gitignore `.vercel` directory

## Test plan
- [ ] Verify workspace page renders milestones with correct currency labels
- [ ] Verify EmptyState renders link-based actions when `actionHref` is provided
- [ ] Verify TypeScript compilation passes with updated tsconfig